### PR TITLE
Add getStaticPaths for dynamic route

### DIFF
--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -1,20 +1,30 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import Container from "../../components/Container.astro";
-import { getEntry } from 'astro:content';
+import { getCollection } from 'astro:content'; // Fetch all articles
 import { formatDate } from "../../utils";
 
 import "../../styles/global.css";
 
+// Define getStaticPaths for dynamic routes
+export async function getStaticPaths() {
+  const articles = await getCollection('blog'); // Adjust based on your content source
+
+  // Return paths for each article slug
+  return articles.map(article => ({
+    params: { slug: article.slug }
+  }));
+}
+
 const { slug } = Astro.params;
 
-if(slug === undefined) {
+if (slug === undefined) {
   throw new Error('Slug is required');
 }
 
 const entry = await getEntry('blog', slug);
 
-if(entry === undefined) {
+if (entry === undefined) {
   return Astro.redirect('/404');
 }
 
@@ -22,28 +32,27 @@ const { Content } = await entry.render();
 ---
 
 <Layout title="Welcome to My site">
-	<main class="space-y-40 mb-40 pt-24">
-	<Container>
-        <section class="bg-white">
-            <div class="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-1 lg:py-16 lg:px-6">
-                <div class="font-light text-gray-500 sm:text-lg">
-                    <a href="/articles" class="inline-flex items-center font-medium text-black hover:text-lime my-4">
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-6 w-6">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18">
-                          </path>
-                      </svg>
-                      <span class="ml-1 font-bold text-lg">All Articles</span>
-                    </a>
-                    <h2 class="mb-4 text-4xl tracking-tight font-extrabold text-gray-900">{entry.data.title}</h2>
-                    <h3 class="text-lg mb-2">Written by {entry.data.author} on {formatDate(entry.data.pubDate)}</h3>
-              
-                    <img src={'/blog/' + entry.data.image} alt="Article Image" class="w-full h-auto rounded-xl my-6" />
-                    <div class="content">
-                      <Content/>
-                    </div>
-                </div>
+  <main class="space-y-40 mb-40 pt-24">
+    <Container>
+      <section class="bg-white">
+        <div class="gap-16 items-center py-8 px-4 mx-auto max-w-screen-xl lg:grid lg:grid-cols-1 lg:py-16 lg:px-6">
+          <div class="font-light text-gray-500 sm:text-lg">
+            <a href="/articles" class="inline-flex items-center font-medium text-black hover:text-lime my-4">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-6 w-6">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18"></path>
+              </svg>
+              <span class="ml-1 font-bold text-lg">All Articles</span>
+            </a>
+            <h2 class="mb-4 text-4xl tracking-tight font-extrabold text-gray-900">{entry.data.title}</h2>
+            <h3 class="text-lg mb-2">Written by {entry.data.author} on {formatDate(entry.data.pubDate)}</h3>
+
+            <img src={'/blog/' + entry.data.image} alt="Article Image" class="w-full h-auto rounded-xl my-6" />
+            <div class="content">
+              <Content />
             </div>
-        </section>
+          </div>
+        </div>
+      </section>
     </Container>
-	</main>
+  </main>
 </Layout>


### PR DESCRIPTION
## Key Changes:

    getStaticPaths():
        This function fetches the list of articles (or slugs) using getCollection('blog'). Adjust this if you're storing articles elsewhere.
        The function returns an array of paths, where each path is an object with a params property containing the slug.

    Error Handling:
        The logic for handling the slug and entry remains the same. If no entry is found, it redirects to a 404 page.